### PR TITLE
Replace "transverse" in docs/comments

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -154,7 +154,9 @@ We say input stream: this is another dimension (we suppose from now on that the 
 
 =head3 Sub-recognizers
 
-The stream management mentioned above is transversal to any grammar: As soon as "terminal" is in reality a referenced symbol, a sub-recognizer is instantiated and it shares the stream with its parent:
+The stream management mentioned above applies to all grammars:
+As soon as "terminal" is in reality a referenced symbol,
+a sub-recognizer is instantiated and it shares the stream with its parent:
 
 
                     TOP RECOGNIZER ON GRAMMAR LEVEL 0
@@ -210,8 +212,7 @@ The stream management mentioned above is transversal to any grammar: As soon as 
 This is recursive: there will as many sub-recognizers instantiated as there are sub-grammars involved.
 For instance, if terminal C<U2> above is a referenced symbol at grammar level C<l>,
 a second sub-recognizer will be instantiated by the first sub-recognizer.
-Every child recognizer is shares all needed transveral information,
-that is everything about stream management.
+Every child recognizer shares all information about stream management.
 The main difference between the top recognizer
 and any child recognizer is that a child recognizer
 is always doing an internal valuation to retreive the span in the input stream for,

--- a/doc/API/README.pod
+++ b/doc/API/README.pod
@@ -34,7 +34,7 @@ Valuation phase.
 
 =back
 
-and a transversal type:
+and a universal type:
 
   typedef struct marpaESLIFString {
     char   *bytep;            /* pointer bytes */
@@ -43,7 +43,11 @@ and a transversal type:
     char   *asciis;           /* ASCII transliteration - never NULL if bytep is not NULL */
   } marpaESLIFString_t;
 
-which describe what is a I<string>: this is a sequence of C<bytel> bytes, starting at C<bytep> in memory, in eventual C<encodingasciis> encoding, and transliterated as much as possible into C<asciis>.
+which describe what is a I<string>:
+this is a sequence of C<bytel> bytes,
+starting at C<bytep> in memory,
+in eventual C<encodingasciis> encoding,
+and transliterated as much as possible into C<asciis>.
 
 =head2 ESLIF
 

--- a/include/marpaESLIF/internal/structures.h
+++ b/include/marpaESLIF/internal/structures.h
@@ -326,7 +326,7 @@ struct marpaESLIF_grammar {
   marpaESLIFAction_t    *defaultRuleActionp;                 /* Default action for rules - never NULL */
   marpaESLIF_internal_rule_action_t defaultRuleActione;      /* For faster lookup */
   marpaESLIFAction_t    *defaultEventActionp;                /* Default action for events - can be NULL */
-  marpaESLIFAction_t    *defaultRegexActionp;                /* Default regex action, it is transversal and applies to all regexes of a grammar - can be NULL */
+  marpaESLIFAction_t    *defaultRegexActionp;                /* Default regex action, applies to all regexes of a grammar - can be NULL */
   int                    starti;                             /* Default start symbol ID - filled during grammar validation */
   char                  *starts;                             /* Default start symbol name - filled during grammar validation - shallow pointer */
   int                   *ruleip;                             /* Array of rule IDs - filled by grammar validation */
@@ -578,8 +578,8 @@ struct marpaESLIFRecognizer {
   size_t                       nSymbolPristinel;
   int                          *symbolArrayPristinep; /* This is shallow pointer! */
 
-  /* Last discard information is NOT available via last_complete because formally there is */
-  /* no token injected in the grammar: discard is a transversal thing. So, we trackb is on */
+  /* Last discard information is NOT available via last_complete because it is not */
+  /* associated with any particular grammar. So, when trackb is on */
   /* the only way to get last discard value is to have an explicit area for it. */
   size_t                       lastDiscardl;    /* Number of bytes */
   char                        *lastDiscards;    /* Bytes */

--- a/src/marpaESLIF.c
+++ b/src/marpaESLIF.c
@@ -10520,7 +10520,8 @@ short marpaESLIFRecognizer_eventb(marpaESLIFRecognizer_t *marpaESLIFRecognizerp,
   }
 
   /* Hook for MARPAESLIF_EVENTTYPE_DISCARD: the associated symbol is NOT pushed to the grammar */
-  /* because a discard is a transversal thing. So if the end user wants to retreive the last */
+  /* because discards apply to all grammars, not any particular one. */
+  /* So if the end user wants to retrieve the last */
   /* discarded data, when trackb is on, he cannot. */
   if ((discardArrayp != NULL) && (discardArrayp->p != NULL) && (discardArrayp->sizel > 0)) {
     if (marpaESLIFRecognizerp->lastDiscards == NULL) {


### PR DESCRIPTION
In several cases I am guessing at the meaning, so you'll need to check that I have not scrambled the intent.

I didn't touch the 3rdparty/ uses of "transverse", because I think they come from elsewhere and would need to be changed at the source.